### PR TITLE
feat: support custom labels for nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <p><img src="assets/screengrab.gif" width="540" alt="Screengrab of the Graph tool" /></p>
 </div>
 
-Wonder how a visualization of your dataset will look? How many authors do you have? How many items have they worked on? And are currently working on! Edits and changes are shown in real-time!
+Wonder how the visualization of your dataset will look? How many authors do you have? How many items have they worked on? And are currently working on! Edits and changes are shown in real-time!
 
 **Explore your data with this plugin, seek out strange corners and data types, boldly go where you could not before!**
 
@@ -26,6 +26,24 @@ Edit `./config/graph-view.json`:
   "query": "*[_type == 'a' || _type == 'b']"
 }
 ```
+
+### Labels
+
+By default, the plugin uses `doc.title || doc.name || doc._id` as the node label.
+
+You can configure labels by passing a key-value object:
+
+```json
+{
+  "query": "*[_type == 'a' || _type == 'b']",
+  "labels": {
+    "a": "someProperty",
+    "b": "anotherProperty",
+  }
+}
+```
+
+### References
 
 For references to turn into graph edges, the entire document must be fetched, but you can also selectively filter what references will be included. For example:
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@sanity/color": "^1.0.0",
     "bezier-easing": "^2.1.0",
     "deep-equal": "^2.0.4",
+    "dlv": "^1.1.3",
     "polished": "^4.0.1",
     "react-force-graph": "^1.37.0",
     "uuid": "^8.3.1"

--- a/src/tool/GraphView.js
+++ b/src/tool/GraphView.js
@@ -7,6 +7,7 @@ import client from 'part:@sanity/base/client'
 import {ForceGraph2D} from 'react-force-graph'
 import {v4 as uuidv4} from 'uuid'
 import BezierEasing from 'bezier-easing'
+import delve from 'dlv'
 import {useRouter} from 'part:@sanity/base/router'
 import pluginConfig from 'config:graph-view'
 
@@ -48,7 +49,11 @@ function getDocTypeCounts(docs) {
 }
 
 function labelFor(doc) {
-  return `${doc.title || doc.name || doc._id}`.trim()
+  const typeLabel = pluginConfig.labels[doc._type]
+  const fallback = doc.title || doc.name || doc._id
+  const label = typeLabel ? delve(doc, typeLabel, fallback) : fallback
+
+  return `${label}`.trim()
 }
 
 function valueFor(doc, maxSize) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2228,6 +2228,11 @@ diff-match-patch@^1.0.4:
   resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
   integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
 
+dlv@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
+  integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"


### PR DESCRIPTION
Hi! 👋🏽 

Thank you for this nice plugin and CMS! 😃 

This PR adds support for custom labels for nodes - with support for nested properties using [dlv](https://github.com/developit/dlv).

My use case is: I have `title` as an object with keys for different languages: `{ en: 'EN', pt: 'PT' }`. And with the default configuration, I get `[object Object]` for all nodes - which is why I added support for nested properties.

Let me know if you have any suggestions or objections to this change.

## Notes

- `dlv` throws when the key/path is `undefined` - [see issue](https://github.com/developit/dlv/issues/35) - that's why we need to check if a label was specified to the `doc._type` before using `delve`;
- Since the default path may return an object, we need the `${label}` part to convert it to a string before calling `.trim` on it.